### PR TITLE
update moment to 2.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15201,9 +15201,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -36234,6 +36234,7 @@
     },
     "jasmine-protractor-browser-log-reporter": {
       "version": "git+ssh://git@github.com/cf-stratos/jasmine-protractor-browser-log-reporter.git#5c9170221db6562f6f2eb128f0652e1c3cf2d668",
+      "integrity": "sha512-dLHeZ1bUEiLgi7LmPECONeABwMupSMEebrlajW928wGyqsg+yT3w599fUqGXG5enDan462sTToqloVjDUCgraQ==",
       "dev": true,
       "from": "jasmine-protractor-browser-log-reporter@cf-stratos/jasmine-protractor-browser-log-reporter",
       "requires": {
@@ -37809,9 +37810,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
       "version": "0.5.28",


### PR DESCRIPTION
Update moment to 2.29.4 to address vulnerabilities: https://security.snyk.io/vuln/npm?search=moment

Related to https://github.com/cloud-gov/private/issues/597