### PR TITLE
Change from go get ..swag to go install ...swag

### DIFF
--- a/build/bk-build.sh
+++ b/build/bk-build.sh
@@ -34,7 +34,7 @@ go env
 
 # Need to install swag in both cases
 echo "Generating OpenAPI documentation..."
-go get github.com/swaggo/swag/cmd/swag@v1.6.7
+go install github.com/swaggo/swag/cmd/swag@v1.6.7
 swag init
 
 if [ "${ACTION}" == "build" ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is old code leftover from the cloudfoundry fork of stratos that uses a deprecated install method. This PR fixes that by using the current process for installation of go packages.

In particular, in the build/bk-build.sh script there is a line that installs swagger using go get. I changed it to go install.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Correcting deprecated code that fails on build.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested locally on my machine pushing out to my sandbox in cloud.gov. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message