### PR TITLE
remove unnecessary <meta> tags from rendered HTML

### DIFF
--- a/src/frontend/packages/core/src/index.html
+++ b/src/frontend/packages/core/src/index.html
@@ -7,10 +7,6 @@
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="stratos_git_project" content="@@stratos_git_project@@">
-  <meta name="stratos_git_branch" content="@@stratos_git_branch@@">
-  <meta name="stratos_git_commit" content="@@stratos_git_commit@@">  
-  <meta name="stratos_build_date" content="@@stratos_build_date@@">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <noscript>
     <style>


### PR DESCRIPTION
## Changes

- remove unnecessary `<meta>` tags from rendered HTML

## security considerations

These <meta> tags appear in the page source even when users are unauthenticated and give too much information about the system state. They have no function for users of the system, so they can be removed.